### PR TITLE
Fix: Resolve Unprocessable Entity error in Swagger UI authorization (#13)

### DIFF
--- a/backend/app/auth/security.py
+++ b/backend/app/auth/security.py
@@ -14,7 +14,7 @@ except Exception:
     # Fallback for bcrypt version compatibility issues
     pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=12)
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login/email")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token") # Updated tokenUrl
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """


### PR DESCRIPTION
- Creates a new /auth/token endpoint that accepts OAuth2PasswordRequestForm (form-data) as expected by Swagger UI for the tokenUrl.
- Updates OAuth2PasswordBearer to use this new /auth/token endpoint.
- The existing /auth/login/email endpoint (expecting JSON) remains unchanged for direct client use.

This change ensures that Swagger UI can correctly authenticate and obtain a bearer token without a 422 Unprocessable Entity error, as it now communicates with an endpoint that handles the expected 'application/x-www-form-urlencoded' content type for token acquisition.

Co-authored-by: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>