### PR TITLE
refactor(user): update user services

### DIFF
--- a/backend/app/user/routes.py
+++ b/backend/app/user/routes.py
@@ -10,7 +10,7 @@ router = APIRouter(prefix="/users", tags=["User"])
 async def get_current_user_profile(current_user: Dict[str, Any] = Depends(get_current_user)):
     user = await user_service.get_user_by_id(current_user["_id"])
     if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=404, detail={"error": "NotFound", "message": "User not found"})
     return user
 
 @router.patch("/me", response_model=Dict[str, Any])
@@ -20,15 +20,15 @@ async def update_user_profile(
 ):
     update_data = updates.model_dump(exclude_unset=True)
     if not update_data:
-        raise HTTPException(status_code=400, detail="No update fields provided.")
+        raise HTTPException(status_code=400, detail={"error": "InvalidInput", "message": "No update fields provided."})
     updated_user = await user_service.update_user_profile(current_user["_id"], update_data)
     if not updated_user:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=404, detail={"error": "NotFound", "message": "User not found"})
     return {"user": updated_user}
 
 @router.delete("/me", response_model=DeleteUserResponse)
 async def delete_user_account(current_user: Dict[str, Any] = Depends(get_current_user)):
     deleted = await user_service.delete_user(current_user["_id"])
     if not deleted:
-        raise HTTPException(status_code=404, detail="User not found")
+        raise HTTPException(status_code=404, detail={"error": "NotFound", "message": "User not found"})
     return DeleteUserResponse(success=True, message="User account scheduled for deletion.")

--- a/backend/app/user/schemas.py
+++ b/backend/app/user/schemas.py
@@ -1,17 +1,15 @@
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr
 from typing import Optional
 from datetime import datetime
 
 class UserProfileResponse(BaseModel):
-    id: str = Field(alias="_id")
+    id: str
     name: str
     email: EmailStr
-    imageUrl: Optional[str] = Field(default=None, alias="avatar")
+    imageUrl: Optional[str] = None
     currency: str = "USD"
     createdAt: datetime
     updatedAt: datetime
-
-    model_config = {"populate_by_name": True}
 
 class UserProfileUpdateRequest(BaseModel):
     name: Optional[str] = None

--- a/backend/app/user/service.py
+++ b/backend/app/user/service.py
@@ -14,17 +14,23 @@ class UserService:
     def transform_user_document(self, user: dict) -> dict:
         if not user:
             return None
-        try:
-            user_id = str(user["_id"])
-        except Exception:
-            return None  # Handle invalid ObjectId gracefully
-        # Ensure ISO 8601 string for dates
+
         def iso(dt):
             if not dt:
                 return None
             if isinstance(dt, str):
                 return dt
-            return dt.isoformat().replace("+00:00", "Z") if dt.tzinfo else dt.isoformat()
+            # Normalize to UTC and append 'Z'
+            try:
+                dt_utc = dt.astimezone(timezone.utc) if getattr(dt, 'tzinfo', None) else dt.replace(tzinfo=timezone.utc)
+                return dt_utc.isoformat().replace("+00:00", "Z")
+            except AttributeError:
+                return str(dt)
+
+        try:
+            user_id = str(user["_id"])
+        except Exception:
+            return None  # Handle invalid ObjectId gracefully
         return {
             "id": user_id,
             "name": user.get("name"),

--- a/docs/user-service.md
+++ b/docs/user-service.md
@@ -36,12 +36,15 @@ Retrieves the profile information for the currently authenticated user.
   "id": "usr_123abc",
   "name": "Jane Doe",
   "email": "jane.doe@example.com",
-  "image_url": "https://example.com/profile.jpg",
+  "imageUrl": "https://example.com/profile.jpg",
   "currency": "USD",
-  "created_at": "2024-01-15T10:00:00Z",
-  "updatedAt": "2024-01-16T12:30:00Z"
+  "createdAt": "2024-01-15T10:00:00Z", // ISO 8601 string, but may be parsed as datetime by backend frameworks
+  "updatedAt": "2024-01-16T12:30:00Z" // ISO 8601 string, but may be parsed as datetime by backend frameworks
 }
 ```
+
+> **Note:**
+> - The backend stores and processes `createdAt` and `updatedAt` as `datetime` objects, but they are serialized to ISO 8601 strings in API responses for JSON compatibility. If you use Python or Pydantic, you may use `datetime` types in your models, but the API will always return them as strings.
 
 **PlantUML Diagram:**
 


### PR DESCRIPTION
## Pull Request: User Service API Alignment & Improvements

**Summary of changes:**
- Standardized all user API responses to use `id` and `imageUrl` fields.
- Date fields (`createdAt`, `updatedAt`) now use `datetime` in backend models and are serialized as ISO 8601 strings in API responses.
- Updated Pydantic models and service logic for field and type consistency.
- Improved error response structure to match documentation.
- Refactored and updated all user service and route tests for new field names and types.
- Clarified date handling in API documentation.

**Result:**  
Backend, tests, and docs for user service are now fully aligned and consistent with the public API contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating the user's currency in profile updates.

* **Bug Fixes**
  * Standardized error responses to include structured error codes and messages.
  * Ensured user profile responses use camelCase keys and ISO 8601 formatted date strings.

* **Documentation**
  * Updated user service documentation to clarify field naming conventions and date formats in API responses.

* **Tests**
  * Refactored user route and service tests for consistency with new response formats and to use synchronous test clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->