### PR TITLE
docs: Add setup guide for UI and authenticated endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,21 @@ You can start developing by editing the files inside the **app** directory. This
    ```bash
    uvicorn main:app --reload
    ```
+#### Proof-of-Concept UI (Streamlit)
 
+This project includes a Streamlit UI for demonstration purposes, available on the `ui-poc` branch.
+
+1.  **Switch Branch**: Ensure you are on the `ui-poc` branch (`git checkout ui-poc`).
+2.  **Start Backend**: Make sure the backend server is running.
+3.  **Install Dependencies**: Navigate to the UI directory and install its requirements:
+    ```bash
+    cd ui 
+    pip install -r requirements.txt
+    ```
+4.  **Run UI**: Start the Streamlit app:
+    ```bash
+    streamlit run app.py
+    ```
 ## 📱 Features in Detail
 
 ### Authentication & Security

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,6 +47,17 @@ The following authentication endpoints are available:
 - `POST /auth/password/reset/request` - Request password reset
 - `POST /auth/password/reset/confirm` - Confirm password reset
 
+### Using Authenticated Endpoints
+
+To test protected endpoints that require a user to be logged in, follow these steps:
+
+1.  **Sign Up**: Create a user account using the `POST /auth/signup/email` endpoint.
+2.  **Log In**: Use the `POST /auth/login/email` endpoint with the same credentials.
+3.  **Copy Token**: From the successful login response, copy the `access_token` value.
+4.  **Authorize**: In the FastAPI docs (`/docs`), click the top-right "Authorize" button. In the popup, paste your token in the format `Bearer <your_token>`.
+5.  **Test**: You can now successfully test any protected endpoint (e.g., `GET /users/me`).
+
+
 ## Database
 
 The application uses MongoDB for data storage. Make sure MongoDB is running and accessible via the connection string in your `.env` file.


### PR DESCRIPTION
This pull request fulfills the follow-up task from the GSSOC getting-started issue, as requested by @Devasy23 .

### Summary of Changes:

* **Updated `backend/README.md`**: Added a new section explaining the step-by-step process for using authenticated endpoints (signup, login, authorize).
* **Updated main `README.md`**: Added a new section with instructions on how to set up and run the Streamlit PoC UI from the `ui-poc` branch.

This documentation should help new contributors get started more easily with both the backend authentication and the PoC user interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for running a Streamlit-based proof-of-concept UI demo, including setup and usage steps.
  * Provided a new guide for testing authenticated API endpoints, detailing how to sign up, log in, obtain an access token, and authorize requests using the FastAPI documentation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->